### PR TITLE
Change leg CFG to match manufacturers

### DIFF
--- a/MSAM/Parts/MSAMLeg.cfg
+++ b/MSAM/Parts/MSAMLeg.cfg
@@ -21,7 +21,7 @@ PART
 	category = Ground
 	subcategory = 0
 	title = Mars Surface Access Module Landing Leg
-	manufacturer = Helios
+	manufacturer = Helios Aerospace
 	description = Landing Leg for Helios' MSAM Lander.
 	attachRules = 1,0,1,1,0
 	mass = 0.15


### PR DESCRIPTION
Change the manufacturer name to show Helios Aerospace instead of Helios to match with the other parts